### PR TITLE
newer version of python not compatable with dependencies yet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "kittentts"
 version = "0.1.0"
 description = "Ultra-lightweight text-to-speech model with just 15 million parameters"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8, <3.13"#New version not compatible with dependencies
 license = {text = "Apache 2.0"}
 authors = [
     {name = "KittenML"}


### PR DESCRIPTION
Fixes issue with a version of Python (3.13) not being compatible with dependencies but still attempts to install. I will find the dependency in question but in the mean time, this should fix users getting a wheel error on `pip install .`

