### PR TITLE
Adding speed param in README since the default generated audio sounds too slow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install https://github.com/KittenML/KittenTTS/releases/download/0.1/kittentt
 from kittentts import KittenTTS
 m = KittenTTS("KittenML/kitten-tts-nano-0.1")
 
-audio = m.generate("This high quality TTS model works without a GPU", voice='expr-voice-2-f' )
+audio = m.generate("This high quality TTS model works without a GPU", voice='expr-voice-2-f', speed=1.0 ) # Adjust the speed to 1.2 if the generated audio is too slow.
 
 # available_voices : [  'expr-voice-2-m', 'expr-voice-2-f', 'expr-voice-3-m', 'expr-voice-3-f',  'expr-voice-4-m', 'expr-voice-4-f', 'expr-voice-5-m', 'expr-voice-5-f' ]
 


### PR DESCRIPTION
The default generated audio is too slow. People might immediately be looking for a way to speed it up. Hence, the suggested change.