### PR TITLE
Remove unused misaki dependency, add phonemizer, add Streamlit demo app

### DIFF
--- a/kittentts/onnx_model.py
+++ b/kittentts/onnx_model.py
@@ -1,4 +1,3 @@
-from misaki import en, espeak
 import numpy as np
 import phonemizer
 import soundfile as sf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "num2words",
     "spacy",
     "espeakng_loader",
-    "misaki[en]>=0.9.4",
+    "phonemizer",
     "onnxruntime",
     "soundfile",
     "numpy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 num2words
 spacy
 espeakng_loader
-misaki[en]>=0.9.4
+phonemizer
 onnxruntime
 soundfile
 numpy


### PR DESCRIPTION
## Summary

- Drop dead `from misaki import en, espeak` import in `onnx_model.py` — `en` and `espeak` were never referenced anywhere in the codebase
- Replace `misaki[en]>=0.9.4` with `phonemizer` in `pyproject.toml` and `requirements.txt` — `phonemizer` is the actual runtime dependency used for phonemization via `phonemizer.backend.EspeakBackend`, but was missing from the declared deps
- Add `app.py`: a minimal Streamlit UI for `kitten-tts-mini-0.8` with voice selector, speed slider, in-browser audio playback, and WAV download

## Why

The `misaki>=0.9.4` requirement blocked installation on Python ≥ 3.13 (misaki requires `<3.13`) and was entirely unnecessary since nothing in the codebase uses it.

## Test plan

- [ ] `pip install -e .` succeeds on Python 3.13+
- [ ] `python -c "from kittentts import KittenTTS"` imports cleanly
- [ ] `streamlit run app.py` launches the demo UI and generates audio