### PR TITLE
integrated expand date function into the preprocessing function

### DIFF
--- a/kittentts/preprocess.py
+++ b/kittentts/preprocess.py
@@ -195,6 +195,15 @@ _RE_DECADE   = re.compile(r"\b(\d{1,3})0s\b")
 # Leading decimal (no digit before the dot): .5, .75
 _RE_LEAD_DEC = re.compile(r"(?<!\d)\.([\d])")
 
+# Match standalone slash dates like D/M/YY or DD/MM/YYYY inside text (1–2 digit day/month; 2-digit or 4-digit year), guarded by non-digit boundaries.
+_RE_DATE_slash = re.compile(r"(?:(?<=^)|(?<=\D))(\d{1,2})/(\d{1,2})/(\d{2}|[1-9]\d{3})(?:(?=$)|(?=\D))")
+
+# Match standalone hyphen dates like D-M-YY or DD-MM-YYYY inside text (1–2 digit day/month; 2-digit or 4-digit year), guarded by non-digit boundaries.
+_RE_DATE_hyphen = re.compile(r"(?:(?<=^)|(?<=\D))(\d{1,2})-(\d{1,2})-(\d{2}|[1-9]\d{3})(?:(?=$)|(?=\D))")
+
+# Match standalone ISO dates like YYYY-M-D or YYYY-MM-DD inside text (4-digit year >=1000; 1–2 digit month/day), guarded by non-digit boundaries.
+_RE_DATE_ISO = re.compile(r"(?:(?<=^)|(?<=\D))([1-9]\d{3})-(\d{1,2})-(\d{1,2})(?:(?=$)|(?=\D))")
+
 
 # ─────────────────────────────────────────────
 # Expansion helpers
@@ -714,6 +723,111 @@ def remove_stopwords(text: str, stopwords: Optional[set] = None) -> str:
     return " ".join(t for t in tokens if t.lower() not in stopwords)
 
 
+def expand_dates(text: str) ->str:
+    
+    """
+    Expand numeric dates in text into spoken-word dates.
+
+    Handles:
+      - hyphen dates: DD/MM/YY, DD/MM/YYYY, MM/DD/YY, MM/DD/YYYY, 
+      - Slash dates: DD-MM-YY, DD-MM-YYYY, MM-DD-YY, MM-DD-YYYY
+      - ISO dates: YYYY-MM-DD
+
+    Ranges / defaults:
+      - Day: 1–31, Month: 1–12 (format-level validation only; no calendar validation like Feb 30)
+      - Year: 2 digits -> 2000–2099, 4 digits -> 1000–9999
+      - Ambiguous D/M vs M/D defaults to DD/MM unless one part > 12 (then that part is treated as day)
+
+    Output: "{ordinal_day} {MonthName} {year_in_words}" (e.g., 03/14/2022 -> 14th March twenty twenty-two).
+    
+    Examples:
+        03/14/2022 -> 14th March twenty twenty-two
+        2022-03-14 -> 14th March twenty twenty-two
+    """
+
+    day_mappings = {
+    1: '1st', 2: '2nd', 3: '3rd', 4: '4th', 5: '5th',
+    6: '6th', 7: '7th', 8: '8th', 9: '9th', 10: '10th',
+    11: '11th', 12: '12th', 13: '13th', 14: '14th', 15: '15th',
+    16: '16th', 17: '17th', 18: '18th', 19: '19th', 20: '20th',
+    21: '21st', 22: '22nd', 23: '23rd', 24: '24th', 25: '25th',
+    26: '26th', 27: '27th', 28: '28th', 29: '29th', 30: '30th',
+    31: '31st'
+    }
+    
+    month_mappings = month_mappings = {
+    1: "January",
+    2: "February",
+    3: "March",
+    4: "April",
+    5: "May",
+    6: "June",
+    7: "July",
+    8: "August",
+    9: "September",
+    10: "October",
+    11: "November",
+    12: "December",
+    }
+    
+    
+    def _replace_common(m: re.Match) -> str:
+        
+        final_arr = []
+        day = int(m.group(1))
+        month= int(m.group(2))
+        year = int(m.group(3))
+        
+        # validation
+        if(year<100):
+            year += 2000
+            
+        if (day ==0 ) or (month ==0 ):
+            return m.group(0)
+        
+        if  not( ( day<=31 and month<=12) or (month<=31 and day<=12)):
+            return m.group(0)    
+    
+        if(month>12):
+            temp = month 
+            month = day 
+            day = temp
+        
+        final_arr.append(day_mappings[day])
+        final_arr.append(month_mappings[month])
+        final_arr.append(number_to_words(year))
+
+        return " ".join(final_arr)
+
+    def _replace_iso(m: re.Match) -> str:
+        
+        final_arr = []
+        year = int(m.group(1))
+        month = int(m.group(2))
+        day = int(m.group(3))  
+        
+        if (day ==0 ) or (month ==0 ):
+            return m.group(0)
+        
+        if  not( ( day<=31 and month<=12) or (month<=31 and day<=12)):
+            return m.group(0)  
+
+        if(month>12):
+            temp = month 
+            month = day 
+            day = temp
+        
+        final_arr.append(day_mappings[day])
+        final_arr.append(month_mappings[month])
+        final_arr.append(number_to_words(year))
+        
+        return " ".join(final_arr)
+    
+    text = _RE_DATE_slash.sub(_replace_common, text)
+    text = _RE_DATE_hyphen.sub(_replace_common, text)
+    return _RE_DATE_ISO.sub(_replace_iso, text)
+
+
 # ─────────────────────────────────────────────
 # Pipeline helper
 # ─────────────────────────────────────────────
@@ -775,6 +889,8 @@ class TextPreprocessor:
 
     def process(self, text: str) -> str:
         cfg = self.config
+        
+        text = expand_dates(text)
 
         if cfg["normalize_unicode"]:
             text = normalize_unicode(text)


### PR DESCRIPTION

## Summary
This PR adds **numeric date expansion** to the preprocessing pipeline so common date formats are converted into a natural spoken form before inference. This prevents the model from reading dates character-by-character (e.g., “zero three slash…”) and improves pronunciation.

### Audio comparison
- `test_date_raw.wav`: output with the **current** preprocessing script  
- `test_date.wav`: output with the **updated** preprocessing script  

Attachments:
- [test_date_raw.wav](https://github.com/user-attachments/files/25832597/test_date_raw.wav)
- [test_date.wav](https://github.com/user-attachments/files/25832598/test_date.wav)

---

## Changes
### 1) New regex patterns (around lines ~215–220)
Added three standalone date matchers (with lookbehind/lookahead to avoid matching parts of larger numbers):

- `_RE_DATE_slash`: slash-separated dates (`D/M/YY`, `DD/MM/YYYY`)
- `_RE_DATE_hyphen`: hyphen-separated dates (`D-M-YY`, `DD-MM-YYYY`)
- `_RE_DATE_ISO`: ISO-style dates (`YYYY-M-D`, `YYYY-MM-DD`)

### 2) New `expand_dates(text)` helper
Introduced `expand_dates(text)` to normalize numeric date formats into a spoken, human-readable form.

**Examples**
- `03/14/2022` → `14th March twenty twenty-two`
- `2022-03-14` → `14th March twenty twenty-two`

**Supported formats**
- Slash style: `D/M/YY`, `DD/MM/YYYY` (also handles `M/D/...` where applicable)
- Hyphen style: `D-M-YY`, `DD-MM-YYYY`
- ISO style: `YYYY-MM-DD`

**Day/month resolution (ambiguity handling)**
Numeric dates like `03/04/2022` are ambiguous. Resolution rules:
- If one of the first two components is `> 12`, that component must be the **day**
- If both are `<= 12`, default to **DD/MM**

### 3) Integrated into the pipeline (around line ~910)
Added `expand_dates(text)` at the beginning of `TextPreprocessor.process()` so dates are expanded before other transformations.

---

## Validation & safety behavior
To avoid accidental or unsafe rewrites, the function applies basic validation before converting:
- If `day == 0` or `month == 0`, leave the original substring unchanged
- Range checks:
  - `day <= 31`
  - `month <= 12`
- No full calendar validation (e.g., `30/02/2022` is not rejected at the calendar level)
- If a match fails validation, the original text is preserved unchanged

---

## Year handling
- Two-digit years are normalized as `2000 + year`  
  - Example: `22` → `2022`
- The normalized year is converted to words via the existing `number_to_words()` helper

---

## Output format
All supported inputs normalize to the canonical spoken form:

`{ordinal_day} {MonthName} {year_in_words}`

Example:
- `14/03/2022` → `14th March twenty twenty-two`

Supporting mappings introduced:
- `day_mappings`: day number → ordinal (e.g., `1 -> 1st`, `2 -> 2nd`, …)
- `month_mappings`: month number → month name (e.g., `1 -> January`, `2 -> February`, …)

---

## Why this matters
This update makes text more TTS-friendly by converting numeric date formats into natural language, improving intelligibility and overall output quality.

--- 

## Date Expansion Examples

The `expand_dates(text)` function converts supported numeric date formats into a spoken form.

### Common cases

| Input | Output |
|---|---|
| `03/14/2022` | `14th March two thousand twenty-two` |
| `2022-03-14` | `14th March two thousand twenty-two` |
| `14/03/2022` | `14th March two thousand twenty-two` |
| `14-03-2022` | `14th March two thousand twenty-two` |
| `03/14/22` | `14th March two thousand twenty-two` |
| `2022-03-21` | `21st March two thousand twenty-two` |

### Ambiguous date handling

When both the first and second numeric parts are `<= 12`, the function defaults to `DD/MM`.

| Input | Output |
|---|---|
| `03/04/2022` | `3rd April two thousand twenty-two` |
| `05/04/2022` | `5th April two thousand twenty-two` |
| `04/05/2022` | `4th May two thousand twenty-two` |
| `01/02/03` | `1st February two thousand three` |

### Mixed format support

| Input | Output |
|---|---|
| `7/8/22` | `7th August two thousand twenty-two` |
| `08/07/2022` | `8th July two thousand twenty-two` |
| `2022-08-07` | `7th August two thousand twenty-two` |
| `03-17-2022` | `17th March two thousand twenty-two` |

### Invalid or protected cases

These cases are intentionally left unchanged when they should not be treated as dates or do not pass validation.

| Input | Output |
|---|---|
| `192.168.03.14` | `192.168.03.14` |
| `03/14` | `03/14` |
| `00/12/2022` | `00/12/2022` |
| `12/00/2022` | `12/00/2022` |
| `2022-00-10` | `2022-00-10` |
| `03 / 14 / 2022` | `03 / 14 / 2022` |
| `2022 - 03 - 14` | `2022 - 03 - 14` |

### Edge cases

| Input | Output |
|---|---|
| `02/30/2022` | `30th February two thousand twenty-two` |
| `02/29/2024` | `29th February two thousand twenty-four` |
| `02/29/2023` | `29th February two thousand twenty-three` |
| `03/14/99` | `14th March two thousand ninety-nine` |
| `03/14/00` | `14th March two thousand` |
| `03/14/68` | `14th March two thousand sixty-eight` |
| `run-2022-03-14-0007` | `run-14th March two thousand twenty-two-0007` |