### PR TITLE
Align package version metadata

### DIFF
--- a/kittentts/__init__.py
+++ b/kittentts/__init__.py
@@ -1,6 +1,6 @@
 from kittentts.preprocess import NormalizedSpan, NormalizedTextResult, normalize_text, normalize_text_result
 
-__version__ = "0.1.0"
+__version__ = "0.8.1"
 __author__ = "KittenML"
 __description__ = "Ultra-lightweight text-to-speech model with just 15 million parameters"
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
## Summary

Aligns the runtime/package metadata with the current `0.8.1` release.

## Details

- Updates `kittentts.__version__` from `0.1.0` to `0.8.1`.
- Fixes the legacy `setup.py` license classifier to Apache Software License, matching the repository license metadata.

Addresses #80 and #87.

## Validation

- `python3 -m unittest -q`
- Editable install in a fresh virtualenv with declared package dependencies.
- Import smoke for `kittentts`, `KittenTTS`, and `normalize_text`.
- Verified `kittentts.__version__` and `importlib.metadata.version("kittentts")` both report `0.8.1`.
