### PR TITLE
Parallelize multi-chunk inference for ~3-4x speedup on multi-sentence text

### DIFF
--- a/kittentts/onnx_model.py
+++ b/kittentts/onnx_model.py
@@ -1,4 +1,5 @@
 import os
+from concurrent.futures import ThreadPoolExecutor
 import espeakng_loader
 from phonemizer.backend.espeak.wrapper import EspeakWrapper
 EspeakWrapper.set_library(espeakng_loader.get_library_path())
@@ -118,11 +119,22 @@ class KittenTTS_1_Onnx:
         return normalize_text(text, locale=locale, return_spans=return_spans)
 
     def generate(self, text: str, voice: str = "expr-voice-5-m", speed: float = 1.0, clean_text: bool=True) -> np.ndarray:
-        out_chunks = []
         if clean_text:
             text = self.preprocessor(text)
-        for text_chunk in chunk_text(text):
-            out_chunks.append(self.generate_single_chunk(text_chunk, voice, speed))
+        text_chunks = chunk_text(text)
+
+        if len(text_chunks) <= 1:
+            out_chunks = [self.generate_single_chunk(c, voice, speed) for c in text_chunks]
+        else:
+            # Phonemization (espeak) keeps internal state and isn't safe to call
+            # concurrently, so prepare every chunk's inputs sequentially first.
+            # ONNX Runtime sessions support concurrent run() calls, so the actual
+            # (and far more expensive) inference step can run in parallel across chunks.
+            prepared_inputs = [self._prepare_inputs(c, voice, speed) for c in text_chunks]
+            max_workers = min(len(prepared_inputs), os.cpu_count() or 4)
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                out_chunks = list(executor.map(self._run_inference, prepared_inputs))
+
         return np.concatenate(out_chunks, axis=-1)
 
     def generate_stream(self, text: str, voice: str = "expr-voice-5-m", speed: float = 1.0, clean_text: bool = True):
@@ -136,25 +148,32 @@ class KittenTTS_1_Onnx:
         for text_chunk in chunk_text(text):
             yield self.generate_single_chunk(text_chunk, voice, speed)
 
-    def generate_single_chunk(self, text: str, voice: str = "expr-voice-5-m", speed: float = 1.0) -> np.ndarray:
-        """Synthesize speech from text.
-        
-        Args:
-            text: Input text to synthesize
-            voice: Voice to use for synthesis
-            speed: Speech speed (1.0 = normal)
-            
-        Returns:
-            Audio data as numpy array
+    def _run_inference(self, onnx_inputs: dict) -> np.ndarray:
+        """Run the ONNX session on already-prepared inputs and trim the output.
+
+        Safe to call concurrently from multiple threads for different inputs
+        on the same session (unlike phonemization, which is not thread-safe).
         """
-        onnx_inputs = self._prepare_inputs(text, voice, speed)
-        
         outputs = self.session.run(None, onnx_inputs)
-        
+
         # Trim audio
         audio = outputs[0][..., :-5000]
 
         return audio
+
+    def generate_single_chunk(self, text: str, voice: str = "expr-voice-5-m", speed: float = 1.0) -> np.ndarray:
+        """Synthesize speech from text.
+
+        Args:
+            text: Input text to synthesize
+            voice: Voice to use for synthesis
+            speed: Speech speed (1.0 = normal)
+
+        Returns:
+            Audio data as numpy array
+        """
+        onnx_inputs = self._prepare_inputs(text, voice, speed)
+        return self._run_inference(onnx_inputs)
     
     def generate_to_file(self, text: str, output_path: str, voice: str = "expr-voice-5-m", 
                           speed: float = 1.0, sample_rate: int = 24000, clean_text: bool=True) -> None:


### PR DESCRIPTION
## Summary

`generate()` previously processed each text chunk (from `chunk_text()`) strictly sequentially: phonemize, then run ONNX inference, one chunk at a time. For multi-sentence input (the common real-world case, not just the README's one-liner demo), this means N sequential `session.run()` calls even though they're independent.

This PR splits the two steps:
- **Phonemization stays sequential.** eSpeak/phonemizer keeps shared internal state and is not safe to call concurrently — confirmed by reproducing a `RuntimeError: number of lines in input and output must be equal` when calling it from multiple threads.
- **ONNX inference now runs concurrently across chunks** via a `ThreadPoolExecutor`, since ONNX Runtime sessions support concurrent `run()` calls on the same session, and profiling showed inference is >99.9% of per-chunk latency (phonemization + tokenization is sub-2ms).

Single-chunk text (the common short-sentence case) is unaffected — it skips the executor entirely and behaves exactly as before.

## Benchmarks

On `kitten-tts-mini-0.8`, a 5-sentence paragraph, 12-core CPU:
- Sequential (current behavior): ~37-38s
- Parallel (this PR): ~8-9s (~4x speedup)

I also benchmarked manual `SessionOptions` tuning (explicit thread counts, `ORT_ENABLE_EXTENDED`, `ORT_PARALLEL` execution mode) as an alternative approach — every manual override I tried was *slower* than ORT's auto-tuned defaults (e.g. forcing all 12 threads was 2.5x slower than the default). So this PR doesn't touch `SessionOptions` at all; it only changes how chunks are dispatched.

## Verification

- Existing test suite passes (`python -m unittest discover -s tests`).
- No NaN/Inf, no clipping, stable RMS across 5 repeated runs of the same multi-chunk input.
- Verified across multiple voices (Bella, Hugo, Kiki, Jasper) and longer inputs (up to 15 chunks).
- Note: the model itself has inherent stochastic sampling (two purely sequential calls on identical input already produce different output, e.g. max abs diff ~0.2-0.3) — this is pre-existing behavior on `main`, unrelated to this change, and confirmed by testing `main` directly before making any modifications.

## Scope

Only `kittentts/onnx_model.py` is touched. `generate_stream()` is left untouched/sequential on purpose, since streaming cares about low time-to-first-chunk rather than total throughput, and parallelizing it would change that latency characteristic.