### PR TITLE
Allow using the system espeak-ng instead of the bundled one

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ m = KittenTTS("KittenML/kitten-tts-mini-0.8", backend="cuda")
 
 Check out `example_cuda.py` 
 
+### Using the system espeak-ng
+
+By default, KittenTTS uses the espeak-ng library bundled with `espeakng_loader`. If you already have espeak-ng installed on your system and prefer to use it, point KittenTTS to it via the standard phonemizer environment variables before importing:
+
+```bash
+export PHONEMIZER_ESPEAK_LIBRARY=/usr/lib/libespeak-ng.so   # path to your espeak-ng shared library
+export ESPEAK_DATA_PATH=/usr/share/espeak-ng-data           # optional: path to your espeak-ng data
+```
+
+When `PHONEMIZER_ESPEAK_LIBRARY` is set, the bundled library is not loaded and `espeakng_loader` does not need to be installed.
+
 ## API Reference
 
 ### `KittenTTS(model_name, cache_dir=None)`

--- a/kittentts/onnx_model.py
+++ b/kittentts/onnx_model.py
@@ -1,8 +1,22 @@
 import os
-import espeakng_loader
+
+try:
+    import espeakng_loader
+except ImportError:
+    espeakng_loader = None
+
 from phonemizer.backend.espeak.wrapper import EspeakWrapper
-EspeakWrapper.set_library(espeakng_loader.get_library_path())
-os.environ['ESPEAK_DATA_PATH'] = espeakng_loader.get_data_path()
+
+# Use the system espeak-ng if the user points to it via the standard
+# PHONEMIZER_ESPEAK_LIBRARY / ESPEAK_DATA_PATH environment variables,
+# otherwise fall back to the library bundled with espeakng_loader.
+if os.environ.get('PHONEMIZER_ESPEAK_LIBRARY'):
+    EspeakWrapper.set_library(os.environ['PHONEMIZER_ESPEAK_LIBRARY'])
+elif espeakng_loader is not None:
+    EspeakWrapper.set_library(espeakng_loader.get_library_path())
+
+if espeakng_loader is not None:
+    os.environ.setdefault('ESPEAK_DATA_PATH', espeakng_loader.get_data_path())
 import numpy as np
 import phonemizer
 import soundfile as sf


### PR DESCRIPTION
Fixes #149

KittenTTS currently hardwires phonemizer to the espeak-ng library bundled with `espeakng_loader` at import time, and overwrites any user-set `ESPEAK_DATA_PATH`. Users who already have espeak-ng installed (e.g. a locally optimized build) have no way to use it.

## Changes

- Respect the standard `PHONEMIZER_ESPEAK_LIBRARY` environment variable: when set, phonemizer is pointed at that library and the bundled one is not loaded.
- Preserve a user-provided `ESPEAK_DATA_PATH` (`setdefault` instead of unconditional overwrite).
- Tolerate `espeakng_loader` import failure, so the package is not required when a system espeak-ng is configured via the env var.
- Document the new option in the README.

Default behavior is unchanged: with no env vars set, the bundled library is used exactly as before. No API changes.

## Testing

- Existing test suite passes (6 passed, 10 subtests).
- Verified with no env vars set that the vendored library is still selected.
- Verified with `PHONEMIZER_ESPEAK_LIBRARY`/`ESPEAK_DATA_PATH` pointing at a system espeak-ng (Homebrew, macOS) that phonemization and full `KittenTTS(...).generate()` synthesis run through the system library.
- Verified import and synthesis still work with `espeakng_loader` uninstalled and the env vars set.